### PR TITLE
Fix issue-list page info text color.

### DIFF
--- a/features/issues/components/issue-list/issue-list.module.scss
+++ b/features/issues/components/issue-list/issue-list.module.scss
@@ -51,7 +51,7 @@
 }
 
 .pageInfo {
-  color: color.$gray-300;
+  color: color.$gray-700;
   font: font.$text-sm-regular;
 }
 


### PR DESCRIPTION
Change color property of "issue-list.module.scss > .pageInfo" to color.$gray-700